### PR TITLE
Add extra debugging when onError triggers on xhr request

### DIFF
--- a/dist/hello.all.js
+++ b/dist/hello.all.js
@@ -726,11 +726,12 @@ hello.utils.extend(hello, {
 hello.utils.extend(hello.utils, {
 
 	// Error
-	error: function(code, message) {
+	error: function(code, message, other_data) {
 		return {
 			error: {
 				code: code,
-				message: message
+				message: message,
+				other_data: other_data
 			}
 		};
 	},
@@ -2438,7 +2439,7 @@ hello.utils.extend(hello.utils, {
 			}
 			catch (_e) {}
 
-			callback(json || error('access_denied', 'Could not get resource'));
+			callback(json || error('access_denied', 'Could not get resource', { event: e, request: r}));
 		};
 
 		var x;


### PR DESCRIPTION
Append the ProgressEvent object and the XHR.request object to the error handling callback to log into the Events log to improve debugging data.
