### PR TITLE
Fix for iOS 18 Safari losing window.parent

### DIFF
--- a/dist/hello.all.js
+++ b/dist/hello.all.js
@@ -400,19 +400,21 @@ hello.utils.extend(hello, {
 		});
 
 		// Use a broadcast channel as an alternative to postMessage when window.parent/window.opener
-		// is not available. Affects Safari + iOS 18 at this time.
-		var broadcastChannel = new BroadcastChannel(callbackId)
-		broadcastChannel.onmessage = (event) => {
-			if (window[callbackId]) {
-				window[callbackId](event.data)
+		// is not available. Affects Safari + iOS 18 on iPads at this time.
+		if ('BroadcastChannel' in self) {
+			var broadcastChannel = new BroadcastChannel(callbackId)
+			broadcastChannel.onmessage = (event) => {
+				if (window[callbackId]) {
+					window[callbackId](event.data)
+				}
 			}
-		}
 
-		// Ensure channel is cleaned up
-		promise.then(
-			() => broadcastChannel.close(),
-			() => broadcastChannel.close()
-		)
+			// Ensure channel is cleaned up
+			promise.then(
+				() => broadcastChannel.close(),
+				() => broadcastChannel.close()
+			)
+		}
 
 		var redirectUri = utils.url(opts.redirect_uri).href;
 
@@ -1685,7 +1687,6 @@ hello.utils.extend(hello.utils, {
 		// (URI Fragments within 302 Location URI are lost over HTTPS)
 		// Loading the redirect.html before triggering the OAuth Flow seems to fix it.
 		else if ('oauth_redirect' in p) {
-
 			var url = decodeURIComponent(p.oauth_redirect);
 			if (isValidUrl(url)) {
 				location.assign(url);
@@ -1751,8 +1752,8 @@ hello.utils.extend(hello.utils, {
 					// Error thrown whilst executing parent callback
 				}
 
-				// On iOS 18 Safari we have lost the window.parent reference. Use the broadcast channel instead.
-				if (window.parent === window) {
+				// On iOS 18 Safari on iPad we may have lost the window.parent reference. Use the broadcast channel instead.
+				if (window.parent === window && 'BroadcastChannel' in self) {
 					var broadcastChannel = new BroadcastChannel(cb)
 					broadcastChannel.postMessage(str);
 					broadcastChannel.close();

--- a/dist/hello.all.js
+++ b/dist/hello.all.js
@@ -399,6 +399,21 @@ hello.utils.extend(hello, {
 			}
 		});
 
+		// Use a broadcast channel as an alternative to postMessage when window.parent/window.opener
+		// is not available. Affects Safari + iOS 18 at this time.
+		var broadcastChannel = new BroadcastChannel(callbackId)
+		broadcastChannel.onmessage = (event) => {
+			if (window[callbackId]) {
+				window[callbackId](event.data)
+			}
+		}
+
+		// Ensure channel is cleaned up
+		promise.then(
+			() => broadcastChannel.close(),
+			() => broadcastChannel.close()
+		)
+
 		var redirectUri = utils.url(opts.redirect_uri).href;
 
 		// May be a space-delimited list of multiple, complementary types
@@ -1734,6 +1749,13 @@ hello.utils.extend(hello.utils, {
 				}
 				catch (e) {
 					// Error thrown whilst executing parent callback
+				}
+
+				// On iOS 18 Safari we have lost the window.parent reference. Use the broadcast channel instead.
+				if (window.parent === window) {
+					var broadcastChannel = new BroadcastChannel(cb)
+					broadcastChannel.postMessage(str);
+					broadcastChannel.close();
 				}
 			}
 


### PR DESCRIPTION
The broadcast channel is only sent data when window.parent isn't available.

One security implication - any frame on the same origin can create a broadcast channel and receive the messages. We are using the randomly generated hellos.js callbackId as the channel name to mitigate this. A longer string might be better.

https://kamihq.slack.com/archives/C7RP9R1QC/p1728503865166379